### PR TITLE
Improve analytics grouping and add tests

### DIFF
--- a/docs/replit-setup.md
+++ b/docs/replit-setup.md
@@ -116,4 +116,4 @@ Setelah setup selesai, test login dengan:
 - **User**: `user@example.com` / `password123`
 - **Shop**: `shop@example.com` / `password123`
 
-Dashboard akan accessible di: `/dashboard`
+Dashboard dapat diakses di `/dashboard`.

--- a/domains/analytics/application/AnalyticsService.test.ts
+++ b/domains/analytics/application/AnalyticsService.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AnalyticsService } from './AnalyticsService';
+
+test('groupEventsByDate counts views and clicks separately', async () => {
+  const events = [
+    { type: 'view', createdAt: new Date('2024-01-01') },
+    { type: 'click', createdAt: new Date('2024-01-01') },
+    { type: 'view', createdAt: new Date('2024-01-02') },
+  ];
+
+  const repo = {
+    findEventsByUserId: async () => events,
+  } as any;
+
+  const service = new AnalyticsService(repo);
+  const result = await service.getUserAnalytics('user-id', 7);
+
+  assert.equal(result.totalViews, 2);
+  assert.equal(result.totalClicks, 1);
+  assert.deepEqual(result.eventsOverTime, {
+    '2024-01-01': { views: 1, clicks: 1 },
+    '2024-01-02': { views: 1, clicks: 0 },
+  });
+});

--- a/domains/analytics/application/AnalyticsService.ts
+++ b/domains/analytics/application/AnalyticsService.ts
@@ -93,12 +93,21 @@ export class AnalyticsService {
     return result;
   }
 
-  private groupEventsByDate(events: any[]): Record<string, number> {
-    const grouped: Record<string, number> = {};
-    events.forEach(event => {
+  /**
+   * Group analytics events by date and count views and clicks separately.
+   */
+  private groupEventsByDate(
+    events: any[],
+  ): Record<string, { views: number; clicks: number }> {
+    const grouped: Record<string, { views: number; clicks: number }> = {};
+    for (const event of events) {
       const date = event.createdAt.toISOString().split('T')[0];
-      grouped[date] = (grouped[date] || 0) + 1;
-    });
+      if (!grouped[date]) {
+        grouped[date] = { views: 0, clicks: 0 };
+      }
+      if (event.type === 'view') grouped[date].views++;
+      if (event.type === 'click') grouped[date].clicks++;
+    }
     return grouped;
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- fix analytics event grouping to track views and clicks separately
- document access path in Replit setup guide
- add test script and unit test for analytics grouping

## Testing
- `npm test`
- `npm run check` *(fails: Type 'string | null' is not assignable to type 'string | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68c5ab2dd8cc8330bdf865388eb28ae7